### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/templates/cloudlens.template.json
+++ b/templates/cloudlens.template.json
@@ -411,7 +411,7 @@
                 },
                 "Handler": "index.handler",
                 "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "30"
             }
         },


### PR DESCRIPTION
CloudFormation templates in quickstart-ixia-eastwind have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.